### PR TITLE
Fix a undefined refresh token bug

### DIFF
--- a/src/lib/space-connector/api.ts
+++ b/src/lib/space-connector/api.ts
@@ -138,6 +138,10 @@ class API {
 
         // Axios request interceptor to set the refresh token
         this.refreshInstance.interceptors.request.use((request) => {
+            if (!this.refreshToken) {
+                throw new Error('Session has expired.');
+            }
+
             request.headers.Authorization = `Bearer ${this.refreshToken}`;
             return request;
         });


### PR DESCRIPTION
Signed-off-by: Jongmin Kim <whdalsrnt@megazone.com>

### 작업 개요

### Jira

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- Refresh Token 만료 시 flushToken 함수를 호출하여 SpaceConnector의 this.refreshToken 변수를 undefined로 변경 중
- 위와 같은 상황에서 또다시 AccessToken이 만료되어 Token Refresh 호출 시 this.refreshToken에 있는 undefined 문자를 그대로 Console API에 전달 중
- this.refreshToken이 undefined일 경우 Refresh 요청을 하지않도록 수정
### 생각해볼 문제
