### PR TITLE
fix: remove pdfmake v0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "lottie-web": "^5.7.6",
         "luxon": "^1.22.0",
         "numeral": "^2.0.6",
-        "pdfmake": "^0.2.4",
         "portal-vue": "^2.1.7",
         "uuid": "^8.3.0",
         "v-click-outside": "^3.0.1",
@@ -3035,57 +3034,6 @@
         "node": ">=14.0.0",
         "npm": ">=6.0.0"
       }
-    },
-    "node_modules/@foliojs-fork/fontkit": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.1.tgz",
-      "integrity": "sha512-U589voc2/ROnvx1CyH9aNzOQWJp127JGU1QAylXGQ7LoEAF6hMmahZLQ4eqAcgHUw+uyW4PjtCItq9qudPkK3A==",
-      "dependencies": {
-        "@foliojs-fork/restructure": "^2.0.2",
-        "brfs": "^2.0.0",
-        "brotli": "^1.2.0",
-        "browserify-optional": "^1.0.1",
-        "clone": "^1.0.4",
-        "deep-equal": "^1.0.0",
-        "dfa": "^1.2.0",
-        "tiny-inflate": "^1.0.2",
-        "unicode-properties": "^1.2.2",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/@foliojs-fork/fontkit/node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/@foliojs-fork/linebreak": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.1.tgz",
-      "integrity": "sha512-pgY/+53GqGQI+mvDiyprvPWgkTlVBS8cxqee03ejm6gKAQNsR1tCYCIvN9FHy7otZajzMqCgPOgC4cHdt4JPig==",
-      "dependencies": {
-        "base64-js": "1.3.1",
-        "brfs": "^2.0.2",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/@foliojs-fork/pdfkit": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.13.0.tgz",
-      "integrity": "sha512-YXeG1fml9k97YNC9K8e292Pj2JzGt9uOIiBFuQFxHsdQ45BlxW+JU3RQK6JAvXU7kjhjP8rCcYvpk36JLD33sQ==",
-      "dependencies": {
-        "@foliojs-fork/fontkit": "^1.9.1",
-        "@foliojs-fork/linebreak": "^1.1.1",
-        "crypto-js": "^4.0.0",
-        "png-js": "^1.0.0"
-      }
-    },
-    "node_modules/@foliojs-fork/restructure": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
-      "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA=="
     },
     "node_modules/@gtm-support/core": {
       "version": "1.3.0",
@@ -22604,31 +22552,6 @@
         "png-js": "^1.0.0"
       }
     },
-    "node_modules/pdfmake": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.4.tgz",
-      "integrity": "sha512-EM39waHUe/Dg1W9C3XqYbpx6tfhYyU14JHZlI1HaW0AUEY32GbkRBjDLGWo9f7z/k3ea6k1p9yyDrflnvtZS1A==",
-      "dependencies": {
-        "@foliojs-fork/linebreak": "^1.1.1",
-        "@foliojs-fork/pdfkit": "^0.13.0",
-        "iconv-lite": "^0.6.3",
-        "xmldoc": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/pdfmake/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -36981,56 +36904,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.3.0.tgz",
       "integrity": "sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w=="
-    },
-    "@foliojs-fork/fontkit": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.1.tgz",
-      "integrity": "sha512-U589voc2/ROnvx1CyH9aNzOQWJp127JGU1QAylXGQ7LoEAF6hMmahZLQ4eqAcgHUw+uyW4PjtCItq9qudPkK3A==",
-      "requires": {
-        "@foliojs-fork/restructure": "^2.0.2",
-        "brfs": "^2.0.0",
-        "brotli": "^1.2.0",
-        "browserify-optional": "^1.0.1",
-        "clone": "^1.0.4",
-        "deep-equal": "^1.0.0",
-        "dfa": "^1.2.0",
-        "tiny-inflate": "^1.0.2",
-        "unicode-properties": "^1.2.2",
-        "unicode-trie": "^2.0.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        }
-      }
-    },
-    "@foliojs-fork/linebreak": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.1.tgz",
-      "integrity": "sha512-pgY/+53GqGQI+mvDiyprvPWgkTlVBS8cxqee03ejm6gKAQNsR1tCYCIvN9FHy7otZajzMqCgPOgC4cHdt4JPig==",
-      "requires": {
-        "base64-js": "1.3.1",
-        "brfs": "^2.0.2",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "@foliojs-fork/pdfkit": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.13.0.tgz",
-      "integrity": "sha512-YXeG1fml9k97YNC9K8e292Pj2JzGt9uOIiBFuQFxHsdQ45BlxW+JU3RQK6JAvXU7kjhjP8rCcYvpk36JLD33sQ==",
-      "requires": {
-        "@foliojs-fork/fontkit": "^1.9.1",
-        "@foliojs-fork/linebreak": "^1.1.1",
-        "crypto-js": "^4.0.0",
-        "png-js": "^1.0.0"
-      }
-    },
-    "@foliojs-fork/restructure": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
-      "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA=="
     },
     "@gtm-support/core": {
       "version": "1.3.0",
@@ -52531,27 +52404,6 @@
         "fontkit": "^1.8.1",
         "linebreak": "^1.0.2",
         "png-js": "^1.0.0"
-      }
-    },
-    "pdfmake": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.4.tgz",
-      "integrity": "sha512-EM39waHUe/Dg1W9C3XqYbpx6tfhYyU14JHZlI1HaW0AUEY32GbkRBjDLGWo9f7z/k3ea6k1p9yyDrflnvtZS1A==",
-      "requires": {
-        "@foliojs-fork/linebreak": "^1.1.1",
-        "@foliojs-fork/pdfkit": "^0.13.0",
-        "iconv-lite": "^0.6.3",
-        "xmldoc": "^1.1.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
       }
     },
     "performance-now": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "lottie-web": "^5.7.6",
     "luxon": "^1.22.0",
     "numeral": "^2.0.6",
-    "pdfmake": "^0.2.4",
     "portal-vue": "^2.1.7",
     "uuid": "^8.3.0",
     "v-click-outside": "^3.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,9 @@
     "paths": {
       "@/*": [
         "src/*"
-      ]
+      ],
+      "pdfmake": ["node_modules/@amcharts/amcharts4/node_modules/pdfmake"],
+      "pdfmake/*": ["node_modules/@amcharts/amcharts4/node_modules/pdfmake/*"]
     },
     "lib": [
       "esnext",

--- a/vue.config.js
+++ b/vue.config.js
@@ -64,6 +64,7 @@ module.exports = {
             symlinks: false,
             alias: {
                 '@vue/composition-api': path.resolve(__dirname, './node_modules/@vue/composition-api/'),
+                pdfmake: path.resolve(__dirname, './node_modules/@amcharts/amcharts4/node_modules/pdfmake/'),
             },
         },
         plugins: [


### PR DESCRIPTION
### To Reviewers
- [ ] Skip

### 작업 분류
- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 기능 개선
- [x] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 작업 내용
![image](https://user-images.githubusercontent.com/50662170/178090409-6e94475a-ed03-4724-9d65-631121126e91.png)

pdfmake를 다른 버전으로 2개 사용 중이라 제거했습니다.
(amchart 내부사용 1개, 추가 설치 1개[맞습니다. 제가 설치했어요ㅎㅎ...])

amcharts4에 있는 pdfmake를 사용하도록 하였고, 경로를 위해 alias를 추가적으로 설정했습니다. 
amrchart 내부에 pdfmake버전은 0.1.72이며, cost explorer에 pdf 다운로드 정상 작동을 확인했습니다.


### 생각해볼 문제
