### PR TITLE
fix: fix the 'status update' bug in alertDetailPage

### DIFF
--- a/src/services/alert-manager/alert/alert-detail/modules/alert-key-info/composables/index.ts
+++ b/src/services/alert-manager/alert/alert-detail/modules/alert-key-info/composables/index.ts
@@ -1,5 +1,5 @@
 import type { ComponentRenderProxy } from '@vue/composition-api';
-import { getCurrentInstance, reactive } from '@vue/composition-api';
+import { computed, getCurrentInstance, reactive } from '@vue/composition-api';
 
 import { cloneDeep } from 'lodash';
 
@@ -31,6 +31,8 @@ interface ParamType {
 export const useAlertInfoItem = (obj: AlertDetailItemState) => {
     const vm = getCurrentInstance()?.proxy as ComponentRenderProxy;
     const state = reactive<AlertDetailItemState>(obj);
+    const alertInfo = computed(() => alertManagerStore.state.alert.alertData);
+
     const cancelEdit = (initialData) => {
         state.isEditMode = false;
         if (typeof initialData === 'object') {
@@ -69,7 +71,10 @@ export const useAlertInfoItem = (obj: AlertDetailItemState) => {
     const updateAlert = async (editMode: EditMode) => {
         try {
             await alertManagerStore.dispatch('alert/updateAlertData', {
-                updateParams: getParams(editMode),
+                updateParams: {
+                    ...alertInfo.value,
+                    ...getParams(editMode),
+                },
                 alertId: state.alertId,
             });
             showSuccessMessage(getMessage(editMode, true), '', vm.$root);

--- a/src/services/alert-manager/alert/alert-detail/modules/alert-summary/AlertSummary.vue
+++ b/src/services/alert-manager/alert/alert-detail/modules/alert-summary/AlertSummary.vue
@@ -164,6 +164,7 @@ export default {
             try {
                 await alertManagerStore.dispatch('alert/updateAlertData', {
                     updateParams: {
+                        ...state.alertInfo,
                         state: alertState,
                     },
                     alertId: props.id,
@@ -178,6 +179,7 @@ export default {
             try {
                 await alertManagerStore.dispatch('alert/updateAlertData', {
                     updateParams: {
+                        ...state.alertInfo,
                         urgency: alertUrgency,
                     },
                     alertId: props.id,


### PR DESCRIPTION
### To Reviewers
- [ ] Skip

### 작업 분류
- [ ] 신규 기능
- [x] 버그 수정
- [ ] 기능 개선
- [ ] 리팩토링 및 구조 변경
- [ ] 기타 (문서, CI/CD 워크플로 변경 등)

### 작업 내용
[설민님이 올려주신 버그](https://cloudone-mz.slack.com/archives/C02U6M1L0LX/p1658203484582099)입니다.
얼럿에대한 데이터 수정 요청을 보낼 때, 기존 상태 업데이트란을 함께 params로 날려주도록 수정하였습니다.
### 생각해볼 문제
클라이언트 단에서 커버가 가능한 영역이긴 한데, 백엔드에서 수정해야할 문제일까요??
![image](https://user-images.githubusercontent.com/50662170/179665909-f8d21839-52e1-43f5-a1c6-553ff1a5efac.png)

얼럿 상태는 엄청 다양한데(상태, 긴급도, 프로젝트, 설명 등등..) 여기서 status update만 요청 파람에서 정의되어있지 않으면 리셋됩니다.